### PR TITLE
fix: update existing PR comment instead of posting new ones

### DIFF
--- a/renovate_helper
+++ b/renovate_helper
@@ -123,27 +123,45 @@ def try_commit_push():
         repo.create_remote('httpsorigin', f"https://{token}@github.com/{GH_OWNER}/{appRepo}")
         repo.remotes.httpsorigin.push().raise_if_error()
 
-def upsert_comment(header, body):
+def upsert_comment(header, body, delete_on_empty=False):
     '''
-    Find an existing PR comment whose body starts with `header` and update it
-    with the new body. If none exists, create a new comment. `header` is
-    prepended to the body — pass `body` without it. No-op if `body` is empty.
+    Find an existing PR comment authored by this token's user whose body
+    starts with `header`. If `body` is non-empty, update the comment to the
+    new body (or create one if no match was found). If `body` is empty and
+    `delete_on_empty` is True, delete the matching comment so a stale
+    message doesn't linger; otherwise no-op. `header` is prepended to `body`
+    — pass `body` without it.
+
+    The ownership check skips comments authored by other users. The GitHub
+    API rejects updates to comments owned by someone else with 403, so
+    matching by header prefix alone would crash the helper if a human ever
+    wrote a comment starting with one of our headers.
     '''
-    if body is None or len(body) == 0:
+    if body is None:
+        body = ""
+    empty = len(body) == 0
+    if empty and not delete_on_empty:
         return
     full_body = header+"\n"+body
     for page in paged(api.issues.list_comments, issue_number=prNum):
         for comment in page:
-            if comment.body.startswith(header):
-                if comment.body != full_body:
-                    api.issues.update_comment(comment_id=comment.id,
-                                              body=full_body)
+            if comment.user.login != bot_login:
+                continue
+            if not comment.body.startswith(header):
+                continue
+            if empty:
+                api.issues.delete_comment(comment_id=comment.id)
                 return
-    api.issues.create_comment(issue_number=prNum,
-                              body=full_body)
+            if comment.body != full_body:
+                api.issues.update_comment(comment_id=comment.id,
+                                          body=full_body)
+            return
+    if not empty:
+        api.issues.create_comment(issue_number=prNum,
+                                  body=full_body)
 
 def comment_values_update(new_comment):
-    upsert_comment(COMMENT_HEADER_VALUES, new_comment)
+    upsert_comment(COMMENT_HEADER_VALUES, new_comment, delete_on_empty=True)
 
 def comment_if_needed(new_comment):
     upsert_comment(COMMENT_HEADER, new_comment)
@@ -186,5 +204,6 @@ assert not repo.bare
 api = GhApi(token=token,
             owner=GH_OWNER,
             repo=appRepo)
+bot_login = api.users.get_authenticated().login
 
 main()

--- a/renovate_helper
+++ b/renovate_helper
@@ -8,7 +8,7 @@ import os
 import subprocess
 import logging
 
-from ghapi.all import GhApi
+from ghapi.all import GhApi, paged
 from git import Repo, Actor
 #from diff_match_patch import diff_match_patch
 import difflib as dl
@@ -123,33 +123,30 @@ def try_commit_push():
         repo.create_remote('httpsorigin', f"https://{token}@github.com/{GH_OWNER}/{appRepo}")
         repo.remotes.httpsorigin.push().raise_if_error()
 
+def upsert_comment(header, body):
+    '''
+    Find an existing PR comment whose body starts with `header` and update it
+    with the new body. If none exists, create a new comment. `header` is
+    prepended to the body — pass `body` without it. No-op if `body` is empty.
+    '''
+    if body is None or len(body) == 0:
+        return
+    full_body = header+"\n"+body
+    for page in paged(api.issues.list_comments, issue_number=prNum):
+        for comment in page:
+            if comment.body.startswith(header):
+                if comment.body != full_body:
+                    api.issues.update_comment(comment_id=comment.id,
+                                              body=full_body)
+                return
+    api.issues.create_comment(issue_number=prNum,
+                              body=full_body)
+
 def comment_values_update(new_comment):
-    if new_comment is not None and len(new_comment) >0 :
-        new_comment = COMMENT_HEADER_VALUES+"\n"+new_comment
-        api.issues.create_comment(issue_number=prNum,
-                                  body=new_comment)
+    upsert_comment(COMMENT_HEADER_VALUES, new_comment)
 
 def comment_if_needed(new_comment):
-    '''
-    If the new_comment doesn't exist as a GH comment, or is different from
-    the one starting with COMMENT_HEADER create or update it
-    '''
-    if new_comment is not None and len(new_comment) >0 :
-        new_comment = COMMENT_HEADER+"\n"+new_comment
-        existing_comments = api.issues.list_comments(issue_number=prNum)
-        found_comment = False
-        for comment in existing_comments:
-            print(comment.body)
-            if comment.body.startswith(COMMENT_HEADER):
-                found_comment = True
-                if comment != new_comment:
-                    api.issues.update_comment(comment_id=comment.id,
-                                              body=new_comment)
-                break
-
-        if found_comment is False:
-            api.issues.create_comment(issue_number=prNum,
-                                      body=new_comment)
+    upsert_comment(COMMENT_HEADER, new_comment)
 
 def process_diff():
     '''


### PR DESCRIPTION
#### Description
The helper posts two comments (the diff summary and the mangled-values report), and both used to stack new copies on every run. They now find the existing comment by header prefix and edit it.

* New upsert_comment(header, body) paginates every PR comment, edits the first one starting with header, and only creates a new one if nothing matches.
* comment_values_update always created a new comment. It now upserts.
* comment_if_needed only looked at the first page of comments, and its is-it-different guard compared a Comment object to a string so it never fired. Both go through upsert_comment now.
