### PR TITLE
feat: optional GitHub commit-status check on Renovate PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Set the following environment variables:
 | CHECKOUT_PATH | yes      | Local path for where to checkout the code to from github to examine                                  |
 | PR_NUM        | yes      | Pull request number in github                                                                        |
 | BOT_LOGIN     | no       | Override the bot's own login used to filter existing PR comments. Only needed when `GITHUB_TOKEN` cannot access `GET /user` — most commonly under the default GitHub Actions token, where you want `BOT_LOGIN=github-actions[bot]`. Falls back to `GIT_NAME` when unset. |
+| STATUS_CONTEXT | no      | Opt in to posting a commit-status check on the PR. Unset or empty means off (default). When set, the value is both the on-switch and the name of the status — use that same string as the required status check in your branch protection rule to block merges. See [PR status check](#pr-status-check). Needs `statuses: write` (see below). |
 
 `https://github.com/<GH_OWNER>/<APP_REPO>` is the path to your repository.
 
@@ -58,3 +59,37 @@ If the `values.yaml` upstream has changed, a patch between old upstream and new 
 The PR will have `values-orig.yaml` updated from upstream, and a commit will be made for this. If this happens your `values.yaml` and upstream will be compared and a unified diff added as a comment to the PR.
 
 It is safe to run this multiple times over the same PR, but `values.yaml` will not be updated more than once in a single PR.
+
+## PR status check
+
+Out of the box the helper just comments on the PR, so it's on you to spot when an upstream `values.yaml` wouldn't merge cleanly. If you'd rather have a check that can block the merge, set `STATUS_CONTEXT`.
+
+`STATUS_CONTEXT` does two jobs: setting it switches the feature on, and whatever you set it to becomes the name of the status that gets posted. Leave it unset and nothing changes from before.
+
+The status goes on via the GitHub Commit Status API (`POST /repos/{owner}/{repo}/statuses/{sha}`), not the Checks API. It's attached to the helper's resulting HEAD commit, the one it just pushed, rather than the `GIT_SHA` you fed in. That matters because the default GitHub Actions `GITHUB_TOKEN` won't re-trigger CI on its own pushes, so if the status landed on the old SHA a required check would just sit there waiting on the new head forever.
+
+What you'll get:
+
+- `success`: every affected chart's `values.yaml` merged cleanly, or upstream's `values.yaml` didn't change. No `.rej` files lying around.
+- `failure`: at least one chart has a `values.yaml.rej`, so the upstream patch wouldn't apply on its own and you'll need to merge it by hand. The helper commits the `.rej` so the failure sticks around. Renovate re-runs the same PR a lot, but the auto-merge only ever runs once per PR, so if the `.rej` weren't committed the check would flip green on the next run with nothing actually fixed. To clear it, fix `values.yaml`, delete the `.rej`, and the next run goes green.
+- `error`: the helper itself fell over. It posts an `error` status and exits non-zero so you can see what happened in the CI logs.
+
+Setting `STATUS_CONTEXT` only posts the status, it won't stop anything on its own. To actually block a bad PR, add a branch protection rule on your target branch with a required status check named the same as your `STATUS_CONTEXT`. With that in place a committed `.rej` keeps the PR from merging, so it never lands on the target branch.
+
+### Extra permission for the status check
+
+The Commit Status API needs `statuses: write`, which is separate from the `contents` and `pull-requests` permissions the helper already uses to push commits and comment.
+
+For the default GitHub Actions `GITHUB_TOKEN`, add it to your workflow's `permissions:` block:
+
+```YAML
+permissions:
+  contents: write
+  pull-requests: write
+  statuses: write
+```
+
+For other token types:
+
+- Classic PAT: the `repo` scope already covers commit statuses.
+- Fine-grained PAT or GitHub App: give it the "Commit statuses" permission, set to read and write.

--- a/renovate_helper
+++ b/renovate_helper
@@ -59,7 +59,7 @@ def update_values_comment(chart_dir):
     rej_path = fs_path(f"{chart_dir}/values.yaml.rej")
     if os.path.exists(rej_path):
         rejects = read_file(rej_path)
-        comment="<details>\n<summary>I'm sorry, but I didn't patch values.yaml completely. Here are the patches which failed:</summary>\n\n```diff\n"
+        comment=f"<details>\n<summary>I'm sorry, but I didn't patch values.yaml in <code>{chart_dir}</code> completely. Here are the patches which failed:</summary>\n\n```diff\n"
         comment+=rejects
         comment+="```\n</details>\n"
         return comment
@@ -80,8 +80,15 @@ def update_values(chart_dir, merge_base):
         run_capture(f"patch -p0 {fs_path(values_path)} <{patch_path}", fs_chart_dir, check=False)
         os.unlink(patch_path)
         repo.index.add(fs_path(values_path))
-        return update_values_comment(chart_dir)
-    return ""
+        # Stage the .rej (when the patch didn't apply cleanly) so a failed
+        # auto-merge survives Renovate's re-runs. values.yaml is only ever
+        # patched once per PR, so without committing the .rej a later run
+        # would lose the failure signal. The committed .rej becomes the
+        # durable source of truth the commit-status check keys off; a human
+        # fixes values.yaml and deletes it to turn the check green.
+        rej_path = fs_path(f"{chart_dir}/values.yaml.rej")
+        if os.path.exists(rej_path):
+            repo.index.add(rej_path)
 
 def handle_chart(chart_path, merge_base):
     '''
@@ -89,7 +96,7 @@ def handle_chart(chart_path, merge_base):
     '''
     chart_dir = os.path.dirname(chart_path)
     update_orig_values(chart_dir)
-    comment_values_update(update_values(chart_dir, merge_base))
+    update_values(chart_dir, merge_base)
 
     fs_chart_dir = fs_path(os.path.dirname(chart_path))
     nowlines = run_capture('wc -l orig-values.yaml', fs_chart_dir)
@@ -167,6 +174,42 @@ def comment_values_update(new_comment):
 def comment_if_needed(new_comment):
     upsert_comment(COMMENT_HEADER, new_comment)
 
+def reject_comment(chart_dirs):
+    '''
+    Scan the affected chart dirs for a leftover/committed values.yaml.rej and
+    build the aggregated "manual merge needed" comment. Returns
+    (comment_body, any_failed). The .rej is the durable signal that the
+    upstream values.yaml could not be auto-merged, so this drives both the PR
+    comment and the commit-status check below regardless of which run first
+    produced it.
+    '''
+    comment = ""
+    failed = False
+    for chart_dir in chart_dirs:
+        chart_comment = update_values_comment(chart_dir)
+        if chart_comment:
+            failed = True
+            comment += chart_comment
+    return comment, failed
+
+def set_commit_status(state, description):
+    '''
+    Post a commit status on the current HEAD so branch protection can gate the
+    PR on it. No-op unless STATUS_CONTEXT is set (the feature is opt-in).
+
+    HEAD is used rather than GIT_SHA so the status lands on the commit the
+    helper may have just pushed (the real new PR head). The default GitHub
+    Actions GITHUB_TOKEN does not re-trigger CI on its own pushes, so a status
+    on the stale checked-out GIT_SHA would leave a required check hanging on
+    the pushed head and block every PR.
+    '''
+    if not status_context:
+        return
+    api.repos.create_commit_status(sha=repo.head.commit.hexsha,
+                                   state=state,
+                                   description=description,
+                                   context=status_context)
+
 def process_diff():
     '''
     Process the diff between where we are now and the target branch
@@ -174,56 +217,78 @@ def process_diff():
     merge_base = repo.merge_base(gitSha, "origin/"+targetBranch)
     diff = repo.head.commit.diff(merge_base)
     comments = ""
+    chart_dirs = []
     for diff_modified in diff.iter_change_type('M'):
         if os.path.basename(diff_modified.a_path) == 'Chart.yaml':
+            chart_dirs.append(os.path.dirname(diff_modified.a_path))
             comments += handle_chart(diff_modified.a_path, merge_base[0].hexsha)
-    return comments
+    return comments, chart_dirs
 
 def main():
     '''
     Main body
     '''
-    helper_comment=process_diff()
+    try:
+        helper_comment, chart_dirs = process_diff()
 
-    print(helper_comment)
-    try_commit_push()
-    comment_if_needed(helper_comment)
-logging.basicConfig(level=logging.INFO)
+        print(helper_comment)
+        try_commit_push()
+        comment_if_needed(helper_comment)
 
-appRepo=os.environ['APP_REPO']
-gitSha=os.environ['GIT_SHA']
-checkoutPath=os.environ['CHECKOUT_PATH']
-prNum=os.environ['PR_NUM']
-token=os.environ['GITHUB_TOKEN']
-GH_OWNER=os.environ['GH_OWNER']
-GIT_EMAIL=os.environ['GIT_EMAIL']
-GIT_NAME=os.environ['GIT_NAME']
-
-repo = Repo(checkoutPath)
-assert not repo.bare
-api = GhApi(token=token,
-            owner=GH_OWNER,
-            repo=appRepo)
-
-# Target branch is derived from the PR via the GH API. TARGET_BRANCH is
-# still honoured as an override for local testing or odd CI shapes, but
-# is no longer required.
-targetBranch = (os.environ.get('TARGET_BRANCH') or '').strip() or api.pulls.get(prNum).base.ref
-try:
-    bot_login = api.users.get_authenticated().login
-except HTTPError as e:
-    # GET /user is not accessible to the GitHub Actions GITHUB_TOKEN —
-    # it responds 403 "Resource not accessible by integration". Other
-    # HTTP errors (network, auth misconfigured, rate-limit, etc.) are
-    # genuine failures and should still surface.
-    if e.code != 403:
+        rejects, failed = reject_comment(chart_dirs)
+        comment_values_update(rejects)
+        if failed:
+            set_commit_status('failure',
+                              'values.yaml needs a manual merge - see the PR comment')
+        else:
+            set_commit_status('success', 'values.yaml is up to date with upstream')
+    except Exception:
+        set_commit_status('error', 'renovate-helm-helper failed - see CI logs')
         raise
-    # Fall back to an explicit BOT_LOGIN env var, defaulting to GIT_NAME
-    # — which matches how this bot's comments are attributed when posted
-    # under the Actions token (e.g. "github-actions[bot]"). Treat an
-    # empty/whitespace-only BOT_LOGIN as unset so it can't poison the
-    # comment.user.login != bot_login check at the only call site.
-    logging.warning("GET /user returned 403; using BOT_LOGIN/GIT_NAME fallback")
-    bot_login = (os.environ.get('BOT_LOGIN') or '').strip() or GIT_NAME
+# Bootstrap is guarded so the module can be imported (e.g. by tests) without
+# requiring the full env / a real checkout / GitHub access. The assignments
+# stay at module scope (an `if` block does not create one), so the functions
+# above keep resolving them as globals at runtime.
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
 
-main()
+    appRepo=os.environ['APP_REPO']
+    gitSha=os.environ['GIT_SHA']
+    checkoutPath=os.environ['CHECKOUT_PATH']
+    prNum=os.environ['PR_NUM']
+    token=os.environ['GITHUB_TOKEN']
+    GH_OWNER=os.environ['GH_OWNER']
+    GIT_EMAIL=os.environ['GIT_EMAIL']
+    GIT_NAME=os.environ['GIT_NAME']
+    # Optional: enables the PR commit-status check and names its context (the
+    # string referenced in branch protection's required checks). Unset = off.
+    status_context = (os.environ.get('STATUS_CONTEXT') or '').strip()
+
+    repo = Repo(checkoutPath)
+    assert not repo.bare
+    api = GhApi(token=token,
+                owner=GH_OWNER,
+                repo=appRepo)
+
+    # Target branch is derived from the PR via the GH API. TARGET_BRANCH is
+    # still honoured as an override for local testing or odd CI shapes, but
+    # is no longer required.
+    targetBranch = (os.environ.get('TARGET_BRANCH') or '').strip() or api.pulls.get(prNum).base.ref
+    try:
+        bot_login = api.users.get_authenticated().login
+    except HTTPError as e:
+        # GET /user is not accessible to the GitHub Actions GITHUB_TOKEN —
+        # it responds 403 "Resource not accessible by integration". Other
+        # HTTP errors (network, auth misconfigured, rate-limit, etc.) are
+        # genuine failures and should still surface.
+        if e.code != 403:
+            raise
+        # Fall back to an explicit BOT_LOGIN env var, defaulting to GIT_NAME
+        # — which matches how this bot's comments are attributed when posted
+        # under the Actions token (e.g. "github-actions[bot]"). Treat an
+        # empty/whitespace-only BOT_LOGIN as unset so it can't poison the
+        # comment.user.login != bot_login check at the only call site.
+        logging.warning("GET /user returned 403; using BOT_LOGIN/GIT_NAME fallback")
+        bot_login = (os.environ.get('BOT_LOGIN') or '').strip() or GIT_NAME
+
+    main()

--- a/test_renovate_helper.py
+++ b/test_renovate_helper.py
@@ -1,0 +1,218 @@
+'''
+Tests for the renovate_helper PR status-check feature.
+
+The script has no .py extension and runs its bootstrap under an
+`if __name__ == '__main__'` guard, so we load it by path with importlib and
+exercise the functions directly, injecting module globals (repo/api/...) as
+needed. Run inside the published image which has ghapi, GitPython, git and
+patch available:
+
+    docker run --rm -v "$PWD":/work -w /work renovate-helper \
+        python3 test_renovate_helper.py
+'''
+import importlib.util
+import os
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+from git import Repo
+
+
+def load_helper():
+    here = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(here, "renovate_helper")
+    # The script has no .py extension, so spell out the source loader.
+    loader = SourceFileLoader("renovate_helper", path)
+    spec = importlib.util.spec_from_loader("renovate_helper", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)   # guard keeps main() from running
+    return mod
+
+
+rhh = load_helper()
+
+
+class FakeRepos:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def create_commit_status(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+class FakeApi:
+    def __init__(self):
+        self.status_calls = []
+        self.repos = FakeRepos(self.status_calls)
+
+
+def init_repo(path):
+    repo = Repo.init(path)
+    cw = repo.config_writer()
+    cw.set_value("user", "name", "tester")
+    cw.set_value("user", "email", "tester@example.com")
+    cw.release()
+    return repo
+
+
+class SetCommitStatusTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.repo = init_repo(self.tmp)
+        # need at least one commit so repo.head.commit resolves
+        open(os.path.join(self.tmp, "f"), "w").close()
+        self.repo.index.add(["f"])
+        self.repo.index.commit("init")
+        self.api = FakeApi()
+        rhh.repo = self.repo
+        rhh.api = self.api
+
+    def test_noop_when_context_unset(self):
+        rhh.status_context = ""
+        rhh.set_commit_status("success", "hi")
+        self.assertEqual(self.api.status_calls, [])
+
+    def test_posts_on_head_when_enabled(self):
+        rhh.status_context = "renovate-helm-helper"
+        rhh.set_commit_status("failure", "needs merge")
+        self.assertEqual(len(self.api.status_calls), 1)
+        call = self.api.status_calls[0]
+        self.assertEqual(call["sha"], self.repo.head.commit.hexsha)
+        self.assertEqual(call["state"], "failure")
+        self.assertEqual(call["context"], "renovate-helm-helper")
+        self.assertEqual(call["description"], "needs merge")
+
+
+class RejectCommentTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        rhh.checkoutPath = self.tmp
+
+    def _mkchart(self, name, with_rej):
+        d = os.path.join(self.tmp, name)
+        os.makedirs(d)
+        if with_rej:
+            with open(os.path.join(d, "values.yaml.rej"), "w") as f:
+                f.write("--- a hunk that failed\n")
+        return name
+
+    def test_clean_is_success(self):
+        c = self._mkchart("clean", with_rej=False)
+        comment, failed = rhh.reject_comment([c])
+        self.assertEqual(comment, "")
+        self.assertFalse(failed)
+
+    def test_rej_is_failure(self):
+        c = self._mkchart("dirty", with_rej=True)
+        comment, failed = rhh.reject_comment([c])
+        self.assertTrue(failed)
+        self.assertIn("a hunk that failed", comment)
+        self.assertIn("dirty", comment)   # chart dir labelled
+
+    def test_mixed_is_failure(self):
+        clean = self._mkchart("ok", with_rej=False)
+        dirty = self._mkchart("bad", with_rej=True)
+        comment, failed = rhh.reject_comment([clean, dirty])
+        self.assertTrue(failed)
+        self.assertIn("bad", comment)
+
+
+class UpdateValuesStagesRejTests(unittest.TestCase):
+    '''The durability guarantee: a failed patch's .rej is staged for commit.'''
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.repo = init_repo(self.tmp)
+        rhh.repo = self.repo
+        rhh.checkoutPath = self.tmp
+
+    def test_failed_patch_stages_rej(self):
+        chart = "mychart"
+        d = os.path.join(self.tmp, chart)
+        os.makedirs(d)
+        # values.yaml is heavily customised so an upstream hunk won't apply.
+        values = "key: MY_CUSTOM_VALUE\ncommon: line\n"
+        orig_old = "key: original\ncommon: line\n"
+        for name, content in (("values.yaml", values),
+                              ("orig-values.yaml", orig_old)):
+            with open(os.path.join(d, name), "w") as f:
+                f.write(content)
+        self.repo.index.add([f"{chart}/values.yaml",
+                             f"{chart}/orig-values.yaml"])
+        merge_base = self.repo.index.commit("base").hexsha
+
+        # Upstream orig-values changes the line whose context is missing from
+        # the customised values.yaml -> patch rejects. values.yaml left as the
+        # merge-base version so update_values takes the patch branch.
+        with open(os.path.join(d, "orig-values.yaml"), "w") as f:
+            f.write("key: changed\ncommon: line\n")
+
+        rhh.update_values(chart, merge_base)
+
+        staged = {k[0] for k in self.repo.index.entries.keys()}
+        self.assertIn(f"{chart}/values.yaml.rej", staged,
+                      "the .rej must be staged so the failure survives re-runs")
+
+    def test_clean_patch_leaves_no_rej(self):
+        chart = "mychart"
+        d = os.path.join(self.tmp, chart)
+        os.makedirs(d)
+        # values.yaml mirrors upstream, so the upstream hunk applies cleanly.
+        base = "key: original\ncommon: line\n"
+        for name in ("values.yaml", "orig-values.yaml"):
+            with open(os.path.join(d, name), "w") as f:
+                f.write(base)
+        self.repo.index.add([f"{chart}/values.yaml",
+                             f"{chart}/orig-values.yaml"])
+        merge_base = self.repo.index.commit("base").hexsha
+
+        with open(os.path.join(d, "orig-values.yaml"), "w") as f:
+            f.write("key: changed\ncommon: line\n")
+
+        rhh.update_values(chart, merge_base)
+
+        staged = {k[0] for k in self.repo.index.entries.keys()}
+        self.assertNotIn(f"{chart}/values.yaml.rej", staged)
+        self.assertFalse(
+            os.path.exists(os.path.join(d, "values.yaml.rej")))
+
+
+class MainFlowTests(unittest.TestCase):
+    '''main() maps merge outcome to the right commit-status state.'''
+    def setUp(self):
+        self._orig = {name: getattr(rhh, name) for name in (
+            "process_diff", "try_commit_push", "comment_if_needed",
+            "comment_values_update", "reject_comment", "set_commit_status")}
+        self.status = []
+        rhh.try_commit_push = lambda: None
+        rhh.comment_if_needed = lambda c: None
+        rhh.comment_values_update = lambda c: None
+        rhh.set_commit_status = lambda state, desc: self.status.append(state)
+
+    def tearDown(self):
+        for name, fn in self._orig.items():
+            setattr(rhh, name, fn)
+
+    def test_clean_run_reports_success(self):
+        rhh.process_diff = lambda: ("body", ["chart"])
+        rhh.reject_comment = lambda dirs: ("", False)
+        rhh.main()
+        self.assertEqual(self.status, ["success"])
+
+    def test_rejects_report_failure(self):
+        rhh.process_diff = lambda: ("body", ["chart"])
+        rhh.reject_comment = lambda dirs: ("rej comment", True)
+        rhh.main()
+        self.assertEqual(self.status, ["failure"])
+
+    def test_crash_reports_error_and_reraises(self):
+        def boom():
+            raise RuntimeError("kaboom")
+        rhh.process_diff = boom
+        with self.assertRaises(RuntimeError):
+            rhh.main()
+        self.assertEqual(self.status, ["error"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
#### Description
Adds an optional GitHub commit-status check to the helm helper, driven by the STATUS_CONTEXT env var.

* STATUS_CONTEXT is off by default; setting it enables the check and names its context, which is the string you require in branch protection
* A clean values.yaml merge reports success, a leftover values.yaml.rej reports failure, and a crash reports error
* The .rej is now committed so a failed merge stays red across Renovate's repeated re-runs of the same PR
* The status is attached to the pushed HEAD rather than GIT_SHA, so a required check does not hang under the default Actions token
* README documents the feature and the extra statuses: write permission
* Adds unit tests for the new behaviour, runnable inside the published image

Have you done ...
* [x] Written a clear commit message
* [x] Unit tests
* [ ] Functional tests
* [x] Manual tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)