### PR TITLE
fix: never commit values.yaml.rej, discard failed patches instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ The status goes on via the GitHub Commit Status API (`POST /repos/{owner}/{repo}
 What you'll get:
 
 - `success`: every affected chart's `values.yaml` merged cleanly, or upstream's `values.yaml` didn't change. No `.rej` files lying around.
-- `failure`: at least one chart has a `values.yaml.rej`, so the upstream patch wouldn't apply on its own and you'll need to merge it by hand. The helper commits the `.rej` so the failure sticks around. Renovate re-runs the same PR a lot, but the auto-merge only ever runs once per PR, so if the `.rej` weren't committed the check would flip green on the next run with nothing actually fixed. To clear it, fix `values.yaml`, delete the `.rej`, and the next run goes green.
+- `failure`: at least one chart has a `values.yaml.rej`, so the upstream patch wouldn't apply on its own and you'll need to merge it by hand. The `.rej` never gets committed, the commit stays clean. When the patch fails the helper throws away the half-patched `values.yaml` and leaves it at the merge base, so every later run patches again and writes the `.rej` back out on disk. Nothing has to live in git for the check to stay red. To clear it, edit `values.yaml` yourself. Once it differs from the merge base the helper backs off, no `.rej` gets written, and the next run goes green.
 - `error`: the helper itself fell over. It posts an `error` status and exits non-zero so you can see what happened in the CI logs.
 
-Setting `STATUS_CONTEXT` only posts the status, it won't stop anything on its own. To actually block a bad PR, add a branch protection rule on your target branch with a required status check named the same as your `STATUS_CONTEXT`. With that in place a committed `.rej` keeps the PR from merging, so it never lands on the target branch.
+Setting `STATUS_CONTEXT` only posts the status, it won't stop anything on its own. To actually block a bad PR, add a branch protection rule on your target branch with a required status check named the same as your `STATUS_CONTEXT`. With that in place a `failure` status keeps the PR from merging, so it never lands on the target branch until you've sorted out `values.yaml` by hand.
 
 ### Extra permission for the status check
 

--- a/renovate_helper
+++ b/renovate_helper
@@ -79,16 +79,21 @@ def update_values(chart_dir, merge_base):
         write_file(patch_path, orig_diff.stdout.decode('utf-8'))
         run_capture(f"patch -p0 {fs_path(values_path)} <{patch_path}", fs_chart_dir, check=False)
         os.unlink(patch_path)
-        repo.index.add(fs_path(values_path))
-        # Stage the .rej (when the patch didn't apply cleanly) so a failed
-        # auto-merge survives Renovate's re-runs. values.yaml is only ever
-        # patched once per PR, so without committing the .rej a later run
-        # would lose the failure signal. The committed .rej becomes the
-        # durable source of truth the commit-status check keys off; a human
-        # fixes values.yaml and deletes it to turn the check green.
+        # A .rej means the patch did not apply cleanly. Never commit a partial
+        # merge: discard the half-patched values.yaml so the working tree stays
+        # identical to the merge base, and never stage the .rej. That keeps the
+        # commit clean AND makes the failure signal self-healing — because
+        # values.yaml is left untouched, every later run re-derives the same
+        # empty values_diff, re-runs the patch, and regenerates the .rej on disk
+        # for reject_comment / the commit-status check. A human resolves it by
+        # editing values.yaml themselves; the helper then backs off (non-empty
+        # values_diff) and the check goes green. The .rej is left on disk for
+        # this run's comment/status scan but is never added to the index.
         rej_path = fs_path(f"{chart_dir}/values.yaml.rej")
         if os.path.exists(rej_path):
-            repo.index.add(rej_path)
+            run_capture(f"git checkout -- {values_path}", checkoutPath)
+        else:
+            repo.index.add(fs_path(values_path))
 
 def handle_chart(chart_path, merge_base):
     '''
@@ -176,12 +181,11 @@ def comment_if_needed(new_comment):
 
 def reject_comment(chart_dirs):
     '''
-    Scan the affected chart dirs for a leftover/committed values.yaml.rej and
-    build the aggregated "manual merge needed" comment. Returns
-    (comment_body, any_failed). The .rej is the durable signal that the
-    upstream values.yaml could not be auto-merged, so this drives both the PR
-    comment and the commit-status check below regardless of which run first
-    produced it.
+    Scan the affected chart dirs for a leftover values.yaml.rej and build the
+    aggregated "manual merge needed" comment. Returns (comment_body,
+    any_failed). The .rej is regenerated on disk by update_values every run the
+    auto-merge fails (it is never committed), so this drives both the PR comment
+    and the commit-status check below from the current run's outcome.
     '''
     comment = ""
     failed = False

--- a/test_renovate_helper.py
+++ b/test_renovate_helper.py
@@ -118,15 +118,18 @@ class RejectCommentTests(unittest.TestCase):
         self.assertIn("bad", comment)
 
 
-class UpdateValuesStagesRejTests(unittest.TestCase):
-    '''The durability guarantee: a failed patch's .rej is staged for commit.'''
+class UpdateValuesFailedPatchTests(unittest.TestCase):
+    '''The clean-commit guarantee: a failed patch commits nothing — the .rej is
+    never staged and the half-patched values.yaml is discarded so the working
+    tree stays at the merge base. The .rej is left on disk only so this run's
+    comment / commit-status scan can see it; the next run regenerates it.'''
     def setUp(self):
         self.tmp = tempfile.mkdtemp()
         self.repo = init_repo(self.tmp)
         rhh.repo = self.repo
         rhh.checkoutPath = self.tmp
 
-    def test_failed_patch_stages_rej(self):
+    def test_failed_patch_commits_nothing_but_leaves_rej_on_disk(self):
         chart = "mychart"
         d = os.path.join(self.tmp, chart)
         os.makedirs(d)
@@ -150,8 +153,20 @@ class UpdateValuesStagesRejTests(unittest.TestCase):
         rhh.update_values(chart, merge_base)
 
         staged = {k[0] for k in self.repo.index.entries.keys()}
-        self.assertIn(f"{chart}/values.yaml.rej", staged,
-                      "the .rej must be staged so the failure survives re-runs")
+        self.assertNotIn(f"{chart}/values.yaml.rej", staged,
+                         "the .rej must never reach the index")
+        # Nothing the helper did here may be committable: the index must still
+        # match the merge base (update_orig_values stages orig-values.yaml
+        # separately; update_values itself must stage nothing on a failed patch).
+        self.assertEqual([], self.repo.index.diff(merge_base),
+                         "a failed patch must leave a clean index")
+        # The partial patch is discarded — working tree back at the merge base.
+        with open(os.path.join(d, "values.yaml")) as f:
+            self.assertEqual(values, f.read())
+        # But the .rej is still on disk for this run's comment/status scan.
+        self.assertTrue(
+            os.path.exists(os.path.join(d, "values.yaml.rej")),
+            "the .rej must remain on disk so reject_comment can see it")
 
     def test_clean_patch_leaves_no_rej(self):
         chart = "mychart"


### PR DESCRIPTION
#### Description
PR #38 added an unconditional stage of values.yaml.rej, so the helper committed and pushed .rej files even on repos that never set STATUS_CONTEXT. A .rej should never end up in a commit.

* update_values now discards the half-patched values.yaml on a failed patch and stages nothing; only a clean apply stages values.yaml
* the .rej is left on disk for the current run's comment and commit-status scan, but is never added to the index
* the failure signal is now self-healing: values.yaml stays at the merge base, so each later run regenerates the .rej rather than relying on a committed copy
* updated the test that asserted the old staging behaviour to assert a clean index and a discarded partial patch

Have you done ...
* [x] Written a clear commit message
* [x] Unit tests
* [ ] Functional tests
* [ ] Manual tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of failed Helm patch applications to ensure the working tree remains clean and matches the original state when patch application fails, preventing partial or stale file states.

* **Tests**
  * Added comprehensive test coverage validating failed patch handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->