### PR TITLE
Keep truncated comments balanced wherever the cut lands

### DIFF
--- a/renovate_helper
+++ b/renovate_helper
@@ -165,17 +165,31 @@ def try_commit_push():
 
 def truncate_comment(body):
     '''
-    Cap a comment body at GitHub's 65536-character limit. The help comment
-    embeds a full values diff inside a ```diff fenced ```<details> block, so a
-    naive cut would leave those unclosed; append a notice that re-closes both
-    and points at the CI logs for the untruncated diff.
+    Cap a comment body at GitHub's 65536-character limit. The body is a run of
+    per-chart blocks, each wrapping its values diff in its own ```diff fence
+    inside a <details> block, so the cut can land anywhere — inside a fence,
+    inside a <details> but past its fence, or cleanly between two closed
+    blocks. Close only what the truncated prefix actually left open (an odd
+    number of ``` fences, an unmatched <details>) so the markdown stays valid
+    instead of injecting a stray fence, then append the CI-log notice.
     '''
     if len(body) <= MAX_COMMENT_CHARS:
         return body
-    notice = ("\n```\n</details>\n\n"
-              "**Comment truncated — the upstream values diff was too large to "
-              "post in full. See the CI logs for the complete diff.**\n")
-    return body[:MAX_COMMENT_CHARS - len(notice)] + notice
+    notice = ("\n\n**Comment truncated — the upstream values diff was too "
+              "large to post in full. See the CI logs for the complete "
+              "diff.**\n")
+    # Reserve room for the notice and the longest closer we might add up front,
+    # so the returned body never exceeds the limit whatever the cut leaves open.
+    closer_max = len("\n```\n</details>\n")
+    truncated = body[:MAX_COMMENT_CHARS - len(notice) - closer_max]
+    closer = ""
+    if truncated.count("```") % 2 == 1:
+        closer += "\n```"
+    if truncated.count("<details>") > truncated.count("</details>"):
+        closer += "\n</details>"
+    if closer:
+        closer += "\n"
+    return truncated + closer + notice
 
 def upsert_comment(header, body, delete_on_empty=False):
     '''

--- a/test_renovate_helper.py
+++ b/test_renovate_helper.py
@@ -235,6 +235,29 @@ class TruncateCommentTests(unittest.TestCase):
         self.assertIn("truncated", out.lower())
         self.assertTrue(out.endswith("\n"))
 
+    def test_no_stray_fence_when_nothing_open(self):
+        # Cut lands in plain text with no open fence/details -> nothing may be
+        # injected, or the notice renders as literal code. (This is the bug the
+        # old unconditional closer caused.)
+        body = "plain text no fences here. " * 5000
+        self.assertGreater(len(body), rhh.MAX_COMMENT_CHARS)
+        out = rhh.truncate_comment(body)
+        self.assertLessEqual(len(out), rhh.MAX_COMMENT_CHARS)
+        self.assertEqual(out.count("```"), 0)
+        self.assertEqual(out.count("</details>"), 0)
+        self.assertIn("truncated", out.lower())
+
+    def test_open_fence_and_details_are_closed(self):
+        # Cut lands deep inside an open ```diff fence within a <details> -> both
+        # must be closed so the trailing notice is real markdown.
+        body = "<details>\n<summary>x</summary>\n\n```diff\n" + "+ line\n" * 20000
+        self.assertGreater(len(body), rhh.MAX_COMMENT_CHARS)
+        out = rhh.truncate_comment(body)
+        self.assertLessEqual(len(out), rhh.MAX_COMMENT_CHARS)
+        self.assertEqual(out.count("```") % 2, 0)
+        self.assertEqual(out.count("<details>"), out.count("</details>"))
+        self.assertIn("truncated", out.lower())
+
 
 class MainFlowTests(unittest.TestCase):
     '''main() maps merge outcome to the right commit-status state.'''


### PR DESCRIPTION
Follow-up to #42 addressing CodeRabbit's review there (merged before the review posted — my miss).

`truncate_comment` unconditionally appended a closing ` ``` ` + `</details>`, assuming the cut always landed inside an open `` ```diff `` fence. But the comment body concatenates multiple per-chart blocks, each with its own fenced `<details>`; a cut landing *between* two already-closed blocks injected a stray fence and made the trailing "truncated" notice render as literal code.

Now the closer is conditional: close a `` ``` `` fence only when the truncated prefix has an odd count, and a `<details>` only when it's unmatched — so the markdown is balanced whether the cut lands inside a fence, inside a `<details>` past its fence, or cleanly between blocks. Worst-case closer length is reserved up front so the result still never exceeds 65536 chars.

Tests: added `test_no_stray_fence_when_nothing_open` (the regression) and `test_open_fence_and_details_are_closed`. 15 passing in the published image.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)